### PR TITLE
Disclosure - handle null in equals() to prevent NPE

### DIFF
--- a/src/main/java/com/authlete/sd/Disclosure.java
+++ b/src/main/java/com/authlete/sd/Disclosure.java
@@ -376,6 +376,11 @@ public class Disclosure
             return true;
         }
 
+        if (obj == null)
+        {
+            return false;
+        }
+
         if (getClass() != obj.getClass())
         {
             return false;


### PR DESCRIPTION
obj.getClass() had a chance to be called while being null